### PR TITLE
CI: stat display

### DIFF
--- a/.github/workflows/stat.yml
+++ b/.github/workflows/stat.yml
@@ -1,0 +1,68 @@
+name: daily progress stat
+
+on:
+  schedule:
+    - cron: '3 0 * * *' # every night
+  workflow_dispatch:
+
+jobs:
+  check_latest:
+    runs-on: ubuntu-latest
+    name: check latest commit
+    outputs:
+      should_run: $${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: print latest commit
+        run: echo ${{ github.sha }}
+      - name: check latest commit less than a day
+        id: should_run
+        continue-on-error: true
+        run: |
+          test -z "$(git rev-list --after='24 hours' ${{ github.sha }})" && echo "should_run=false" >> $GITHUB_OUTPUT
+          exit 0
+
+  run_translate:
+    runs-on: ubuntu-20.04
+    needs: check_latest
+    if: ${{ needs.check_latest.outputs.should_run != 'false' }}
+    name: Run translation process
+    steps:
+      - uses: actions/checkout@v3
+      - name: make directory
+        run: mkdir -p source tm dictionary
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+      - name: Prepare gradle config
+        run: |
+          echo "plugins { id 'org.omegat.gradle' version '1.5.9' }" > build.gradle
+          echo "omegat {version='5.7.1'" >> build.gradle
+          echo "projectDir='$rootDir'}" >> build.gradle
+        shell: bash
+      - name: Generate translation
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: translate
+          gradle-version: 7.5.1
+      - name: upload stats
+        uses: actions/upload-artifact@v3
+        with:
+          name: stats
+          path: omegat/project_stats.txt
+
+  report_coverage:
+    runs-on: ubuntu-20.04
+    needs: run_translate
+    name: Report statistics summary
+    steps:
+      - name: download stats
+        uses: actions/download-artifact@v3
+        with:
+          name: stats
+          path: omegat
+      - name: Report coverage
+        uses: miurahr/omegat-stat@v2.0.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This github actions config allow project to automatically calculate translation stat and show it on github actions web page.

You can see live example on L10N japanese project.

ex https://github.com/OmegaT-L10N/ja/actions/runs/4299132812